### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Provides CSS files ready to use for [selectize.js](http://selectize.github.io/se
 <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.2/js/standalone/selectize.min.js"></script>
 
 <!-- Include a Bootswatch-selectize css instead, choose one in the css folder corresponding to your selected bootswatch theme -->
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/selectize-bootswatch/1.0/selectize.cosmo.css" />
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/Syone/selectize-bootswatch@1.0/css/selectize.cosmo.css" />
 
 <!-- Create your selectize component as usual -->
 <script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/Syone/selectize-bootswatch.

Feel free to ping me if you have any questions regarding this change.